### PR TITLE
Php memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,13 +71,15 @@ jobs:
           paths:
             - vendor
 
+      -run: php -i
+
       # seedingの準備
       - run:
           name: シーディングの準備
           working_directory: backend
           command: composer dump-autoload
 
-      # run seeding
+      # run migrate
       - run:
           name: テストのためにデータベースのマイグレーション
           working_directory: backend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
           paths:
             - vendor
 
-      -run: php -i
+      - run: php -i
 
       # seedingの準備
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,13 @@ jobs:
           paths:
             - vendor
 
-      - run: php -i
+      - run:
+          name: メモリの上限値を変更
+          command: sudo sh -c "echo \"memory_limit = 2048M\" > /usr/local/etc/php/conf.d/memory.ini"
+
+      - run:
+          name: メモリ上限の確認
+          command: php -i | grep memory_limit
 
       # seedingの準備
       - run:

--- a/backend/tests/Feature/ExposureControllerTest.php
+++ b/backend/tests/Feature/ExposureControllerTest.php
@@ -51,10 +51,9 @@ class ExposureControllerTest extends TestCase
         $response = $this->actingAs($user)
             ->get(route('RD.list'));
 
-
-            $response->assertStatus(200)
+        $response->assertStatus(200)
             ->assertViewIs('Rd.list');
 
         $this->withoutExceptionHandling();
-        }
+    }
 }


### PR DESCRIPTION
What
・memory.iniをCircleCIのrunで作成

Why
・composer での作業中にメモリ不足により処理が停止してしまうから